### PR TITLE
Added 'use' option. Fix for PHP Strict (2048) error when calling listSou...

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Add a configuration to your database.php in app/config/
           'ns' => 'namespace',
           'container' => 'session_key',
         )
+        'use' => SOAP_ENCODED // optional - used only for non wsdl mode
     );
 
 Then in your model set:
@@ -37,18 +38,29 @@ Then in your model set:
 
 And you're ready to go.
 
+Asuming that you parameters are:
+
+    $params = array('param1' => 'value1', 'param2' => 'value2');
+
 In your controller you can now use
 
-    $this->Model->query('SoapMethod', array('mySoapParams'));
+    $this->Model->query('SoapMethod', array($params));
 
-or
-
-    $this->Model->SoapMethod(array('mySoapParams'));
+**Important**: notice the *array()* enclosing your params array.
 
 or with header data
 
-    $this->Model->query('SoapMethod', array('mySoapParams'), array('mySoapHeaderParams'));
-    
+    $headerParams = array('headerParam1' = 'value1', 'headerParam2' => 'value2');
+
+    $this->Model->query('SoapMethod', array($params), array($headerParams);
+
+**Important**: again, notice the *array()* enclosing your params and header params arrays.
+
+or
+
+    $this->Model->SoapMethod($params);
+
+**Important**: notice the difference with the previous examples. In this case DON'T enclose the params with *array()*.
 
 ## Thanks for updating
 

--- a/SoapSource.php
+++ b/SoapSource.php
@@ -152,7 +152,7 @@ class SoapSource extends DataSource {
      *
      * @return array List of SOAP methods
      */
-    public function listSources($data = NULL) {
+    public function listSources($data = null) {
        return $this->client->__getFunctions();
     }
     

--- a/SoapSource.php
+++ b/SoapSource.php
@@ -106,6 +106,9 @@ class SoapSource extends DataSource {
         if(!empty($this->config['proxy_port'])) {
             $options['proxy_port'] = $this->config['proxy_port'];
         }
+        if(!empty($this->config['use'])) {
+            $options['use'] = $this->config['use'];
+        }
         
          /** Workaround to prevent SoapClient throwing a RuntimeException **/
         if (extension_loaded('curl') && Configure::read('debug') > 0 && !empty($this->config['wsdl']) && empty($this->config['curl_off']))
@@ -149,7 +152,7 @@ class SoapSource extends DataSource {
      *
      * @return array List of SOAP methods
      */
-    public function listSources() {
+    public function listSources($data = NULL) {
        return $this->client->__getFunctions();
     }
     
@@ -179,7 +182,7 @@ class SoapSource extends DataSource {
             $headerData = $args[2];
         } elseif(count($args) > 2 && !empty($args[1])) {
             $method = $args[0];
-            $queryData = $args[1][0];
+            $queryData = $args[1];
         } 
         
         if (!empty($headerData)) {


### PR DESCRIPTION
Added 'use' option. Fix for PHP Strict (2048) error when calling listSources without data. Usage instructions enhanced and clarified. Solves an error returning parameters from array when doing `elseif(count($args) > 2 && !empty($args[1])`.
